### PR TITLE
Add GA and Meta components

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,9 +1,25 @@
 <script>
+  import seo from "./config/seo.json";
+
   import Header from "./components/page/Header.svelte";
   import Footer from "./components/page/Footer.svelte";
 
+  import GaTrackingHead from "./components/seo/GATracking.svelte";
+  import Meta from "./components/seo/Meta.svelte";
+
+
   let message = "Hello world!"
+
 </script>
+
+<Meta
+{seo}
+/>
+
+<GaTrackingHead
+{seo}
+/>
+
 
 <Header/>
 

--- a/src/components/seo/GATracking.svelte
+++ b/src/components/seo/GATracking.svelte
@@ -1,0 +1,50 @@
+<script>
+    import { onMount } from "svelte";
+
+    export let seo;
+
+    onMount(() => {
+        //Initialize data layer
+        // @ts-ignore
+        window.dataLayer = window.dataLayer || [];
+        // @ts-ignore
+        window.dataLayer.push({
+            event: "dataLayer-initialized",
+            pageLevel: "story",
+            pageSection: seo.pageSection,
+            subsection: seo.subsection,
+            author: seo.author,
+            contentSource: "star tribune",
+            pageName: seo.pageName,
+            articleId: seo.articleId,
+        });
+        //End initialize data layer
+
+        //Google Tag Manager
+        (function (w, d, s, l, i) {
+            w[l] = w[l] || [];
+            w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+            var f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s),
+                dl = l != "dataLayer" ? "&l=" + l : "";
+            // @ts-ignore
+            j.async = true;
+            // @ts-ignore
+            j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+            f.parentNode.insertBefore(j, f);
+        })(window, document, "script", "dataLayer", "GTM-KD2KG7V");
+        //End Google Tag Manager
+    });
+</script>
+
+<!-- Google Tag Manager (noscript) -->
+<noscript>
+    <iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-KD2KG7V"
+        title=""
+        height="0"
+        width="0"
+        style="display:none;visibility:hidden"
+    ></iframe>
+</noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/src/components/seo/Meta.svelte
+++ b/src/components/seo/Meta.svelte
@@ -1,0 +1,30 @@
+<script>
+    export let seo;
+</script>
+
+<svelte:head>
+        <!-- Additional meta tags -->
+        <link rel="canonical" href={seo.canonicalURL}/>
+        <meta itemprop="name" content= {seo.pageName}/>
+        <meta name="description" content= {seo.articleDescription}/>
+        <meta itemprop="description" content={seo.articleDescription} />
+        <meta
+            itemprop="image"
+            content={seo.shareImageURL}
+        />
+        <meta name="twitter:site" content="@StarTribune" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta property="og:site_name" content="Star Tribune" />
+        <meta property="og:type" content="article" />
+        <meta property="og:site_name" content="Star Tribune" />
+        <meta property="og:title" content={seo.pageName} />
+        <meta property="og:description" content={seo.articleDescription} />
+        <meta property="og:url" content={seo.shareImageURL} />
+        <meta
+            property="og:image"
+            content={seo.shareImageURL}
+        />
+        <meta property="og:image:width" content="1680" />
+        <meta property="og:image:height" content="876" />
+        <!-- end additional meta tags -->
+</svelte:head>

--- a/src/config/seo.json
+++ b/src/config/seo.json
@@ -1,0 +1,10 @@
+{
+    "pageName": "Your headline here as it appears in Arc pointer file",
+    "articleDescription": "This can likely be your dek",
+    "author": "firstname lastname,firstname lastname,firstname lastname",
+    "pageSection": "top level primary circulation in Arc",
+    "subsection": "bottom level primary circulation in Arc",
+    "articleId": "arc id",
+    "canonicalURL": "Production endpoint url",
+    "shareImageURL": "relative path to share image"
+}


### PR DESCRIPTION
This branch passes the file seo.json as a prop into the Google Analytics and meta tag components. The idea is that someone will never have to edit either of these components, just the underlying json file.