### PR TITLE
Remove pym.js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "strib-svelte-vite-template",
       "version": "0.0.0",
-      "dependencies": {
-        "pym.js": "^1.3.2"
-      },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5.0.1",
         "autoprefixer": "^10.4.19",
@@ -2467,12 +2464,6 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pym.js": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/pym.js/-/pym.js-1.3.2.tgz",
-      "integrity": "sha512-/fFzHFB4BTsJQP5id0wzUdYsDT4VPkfAxk+uENBE9/aP6YbvhAEpcuJHdjxqisqfXOCrcz7duTK1fbtF2rz8RQ==",
       "license": "MIT"
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,5 @@
     "tailwindcss": "^3.4.4",
     "vite": "^6.0.1",
     "vite-plugin-compression": "^0.5.1"
-  },
-  "dependencies": {
-    "pym.js": "^1.3.2"
   }
 }


### PR DESCRIPTION
Pym.js shouldn't be needed now that this template can be injected directly into an article page