### PR TITLE
Add "fullBleed" GridRow variant

### DIFF
--- a/src/components/ArticleBody/ArticleBody.svelte
+++ b/src/components/ArticleBody/ArticleBody.svelte
@@ -3,7 +3,31 @@
 ### ArticleBody component
 This is a general workspace illustrating what an article body might look like if you use only the included components.  
 ArticleBody doesn't accept any props. All contents will need to be hand-placed by a designer directly inside this component.  
-In this example, Grid and GridRow help establish the width of the article body's contents. Documentation included with those components and accessed by VSCode tooltip explains each component in greater detail detail.
+In this example, Grid and GridRow help establish the width of the article body's contents. 
+Documentation included with those components and accessed by VSCode tooltip explains each component in greater detail detail.
+
+#### State in this component
+- innerWidth: int - pixel width of the viewport.
+- isMobile: boolean - derived from innerWidth, true if less than 768 pixels
+- isTablet: boolean - derived from innerWidth, true if between 768 pixels inclusive and 1024 pixels exclusive
+- isDesktop: boolean - derived from innerWidth, true if greater than 1024 pixels inclusive
+
+#### Using state in this component
+You can use any of the three derived states to render different variants of a GridRow component reactively.
+The following example uses a ternary to render an image edge-to-edge on mobile but inline otherwise.
+
+#### Example
+```svelte
+  <GridRow
+    variant={isMobile ? "fullBleed" : "inline"}
+  >
+    <Image
+      src="https://arc.stimg.co/startribunemedia/4SPNT7DI36ANT2SOB5N5EJAIJU.jpg"
+      alt="Descriptive alt text"
+      caption="Caption tk tk tk"
+    />
+  </GridRow>
+```
 -->
 
 <script>
@@ -12,7 +36,14 @@ In this example, Grid and GridRow help establish the width of the article body's
   import Subhead from "./_Subhead.svelte";
   import Paragraph from "./_Paragraph.svelte";
   import Image from "../Image/Image.svelte";
+
+  let innerWidth = $state(0);
+  let isMobile = $derived(innerWidth < 768);
+  let isTablet = $derived(innerWidth >= 768 && innerWidth < 1024);
+  let isDesktop = $derived(innerWidth >= 1024);
 </script>
+
+<svelte:window bind:innerWidth />
 
 <Grid additionalClasses={"gap-y-5"}>
   <GridRow variant={"inline"} additionalClasses={"gap-y-5"}>
@@ -41,29 +72,33 @@ In this example, Grid and GridRow help establish the width of the article body's
     >
   </GridRow>
 
-  <GridRow>
+  <GridRow variant={"fullBleed"}>
     <Image
-      variant={"fullBleed"}
+      variant={"captionCentered"}
       src="https://arc.stimg.co/startribunemedia/4SPNT7DI36ANT2SOB5N5EJAIJU.jpg"
       alt="Descriptive alt text"
       caption="Caption tk tk tk"
     />
   </GridRow>
 
-  <GridRow variant={"inline"} additionalClasses={"gap-y-5"}>
+  <GridRow variant="inline">
     <Paragraph
-      >Quam consectetur iure impedit consequatur deleniti esse asperiores
-      corrupti et facilis debitis aut aspernatur consequuntur, ipsum repellendus
-      maiores, vero harum quis non eum voluptates. Ex quis repudiandae
-      reiciendis sunt neque?</Paragraph
+      >Voluptate molestiae, perferendis iusto dolor officiis eaque cum quisquam
+      quidem, doloremque dicta temporibus fuga ducimus voluptatum excepturi
+      ratione laborum ab omnis quibusdam, accusamus vel eum culpa repellendus
+      exercitationem. Fugit, consequatur!</Paragraph
     >
+  </GridRow>
 
+  <GridRow variant={isMobile ? "fullBleed" : "inline"}>
     <Image
       src="https://arc.stimg.co/startribunemedia/4SPNT7DI36ANT2SOB5N5EJAIJU.jpg"
       alt="Descriptive alt text"
       caption="Caption tk tk tk"
     />
+  </GridRow>
 
+  <GridRow variant="inline" additionalClasses={"gap-y-5"}>
     <Subhead>Subhead</Subhead>
 
     <Paragraph
@@ -85,7 +120,7 @@ In this example, Grid and GridRow help establish the width of the article body's
     >
   </GridRow>
 
-  <GridRow>
+  <GridRow variant={isMobile ? "fullBleed" : "default"}>
     <Image
       src="https://arc.stimg.co/startribunemedia/4SPNT7DI36ANT2SOB5N5EJAIJU.jpg"
       alt="Descriptive alt text"

--- a/src/components/Grid/_GridRow.svelte
+++ b/src/components/Grid/_GridRow.svelte
@@ -2,15 +2,16 @@
 @component
 ### GridRow component
 Renders a div that spans a configurable number of columns when used within a parent Grid component.  
-Wrap this component around additional markup to control that markup's width and position within its grid layout.
+Wrap this component around additional markup to control that markup's width and position within a parent's grid layout.
 
 #### Optional properties
-- variant: "default" | "inline";
+- variant: "default" | "inline" | "fullBleed";
 - additionalClasses: string;
 
 #### Variants
 - default: GridRow spans the full width of its parent grid. This is the default behavior if the optional variant property is not passed in.  
 - inline: GridRow spans the full width of its parent grid on mobile, and the middle six columns of its parent grid on tablet and desktop.
+- fullBleed: GridRow spans the width of the page up to 1800px. 
 
 #### Example
 ```svelte
@@ -25,20 +26,19 @@ Wrap this component around additional markup to control that markup's width and 
 -->
 
 <script>
-  /** @type {{variant?: "default" | "inline"; additionalClasses?: string; children?: function}} */
+  /** @type {{variant?: "default" | "inline" | "fullBleed"; additionalClasses?: string; children?: function}} */
   let { variant = "default", additionalClasses = "", children } = $props();
 
-  let variantStyles = $state("");
-
-  switch (variant) {
-    case "default":
-      variantStyles = "col-span-full";
-      break;
-    case "inline":
-      variantStyles =
-        "col-span-full grid md:col-start-2 md:col-span-6 lg:col-start-4";
-      break;
-  }
+  let variantStyles = $derived.by(() => {
+    switch (variant) {
+      case "default":
+        return "col-span-full";
+      case "inline":
+        return "col-span-full grid md:col-start-2 md:col-span-6 lg:col-start-4";
+      case "fullBleed":
+        return "col-span-full w-screen relative left-1/2 -translate-x-1/2 max-w-[1800px]";
+    }
+  });
 </script>
 
 <div class="{variantStyles} {additionalClasses}">

--- a/src/components/Hero/Hero.svelte
+++ b/src/components/Hero/Hero.svelte
@@ -54,7 +54,7 @@ Renders a visual replica of the Immersive Template hero.
   } = $props();
 </script>
 
-<Grid additionalClasses="gap-y-8 md:gap-y-10 md:justify-items-center">
+<Grid additionalClasses="gap-y-8 md:gap-y-10">
   <GridRow>
     <div class="flex justify-center my-6">
       <SectionLabel>{sectionLabel}</SectionLabel>
@@ -66,17 +66,19 @@ Renders a visual replica of the Immersive Template hero.
   </GridRow>
 
   {#if heroImageUrl}
-    <GridRow>
+    <GridRow variant={"fullBleed"}>
       <Image
+        variant={"captionCentered"}
         src={heroImageUrl}
         alt={heroImageAltText}
         caption={heroImageCaption}
-        variant={"fullBleed"}
       />
     </GridRow>
   {/if}
 
-  <GridRow additionalClasses="md:max-w-[535px] md:text-center lg:max-w-[712px]">
+  <GridRow
+    additionalClasses="justify-self-center md:max-w-[535px] md:text-center lg:max-w-[712px]"
+  >
     <div class="flex flex-col gap-y-5 md:justify-items-center md:items-center">
       <Dek>
         {dek}

--- a/src/components/Image/Image.svelte
+++ b/src/components/Image/Image.svelte
@@ -7,27 +7,29 @@ Renders a figure tag with nested image and figcaption tags in the style of the I
 - src: string;
 - alt: string;
 - caption: string;
-- variant: "default" | "fullBleed";
+- variant: "default" | "captionCentered";
 
 #### Variants
-- default: Figure tag renders renders edge-to-edge on mobile (i.e. full width inside its container plus 32 pixels in negative margin). Figure renders the width of its parent container on tablet and desktop.
-- fullBleed: Figure tag renders edge-to-edge across mobile, tablet and desktop up to 1800 pixels. 
+- default: Figure tag renders to the size of its parent container. On mobile, caption will be indented. On tablet and desktop, caption will align with left edge of container. Recommended for use inside "fullBleed" GridRow variant at mobile sizes and "default" and "inline" GridRow variants at all viewport sizes.
+- captionCentered: Figure tag renders to the size of its parent container. On mobile, caption will be indented. On tablet and desktop, caption will be centered. Ideal inside "fullBleed" GridRow variant at all viewport sizes.
 
 #### Example
 ```svelte
+<GridRow variant="fullBleed">
 <Image
 src="https://arc.stimg.co/startribunemedia/4SPNT7DI36ANT2SOB5N5EJAIJU.jpg"
 alt="Please don't leave out the alt text!"
 caption="This image will render as the fullBleed variant"
-variant="fullBleed"
+variant="captionCentered"
 >
+</GridRow>
 ```
 -->
 
 <script>
   import ImageCaption from "./_ImageCaption.svelte";
 
-  /** @type {{src?: string; alt?: string; caption?: string; variant?: "default" | "fullBleed"}} */
+  /** @type {{src?: string; alt?: string; caption?: string; variant?: "default" | "captionCentered"}} */
   let {
     src = "",
     alt = "",
@@ -41,19 +43,19 @@ variant="fullBleed"
 
   switch (variant) {
     case "default":
+      variantStylesCaption = "md:px-0";
       break;
-    case "fullBleed":
-      variantStylesFigure = "w-screen max-w-[1800px] justify-self-center";
+    case "captionCentered":
       variantStylesCaption = "md:text-center";
       break;
   }
 </script>
 
-<figure class="-mx-4 md:mx-0 {variantStylesFigure}">
+<figure class={variantStylesFigure}>
   {#if src}
     <img {src} {alt} class="{variantStylesImg} w-full mb-2" />
   {/if}
-  <ImageCaption additionalClasses="px-4 md:px-0 {variantStylesCaption}">
+  <ImageCaption additionalClasses="px-4 {variantStylesCaption}">
     {caption}
   </ImageCaption>
 </figure>


### PR DESCRIPTION
This merge adds a new variant to GridRow for fullbleed presentation. It also removes the "fullBleed" variant from the Image component, and introduces some boolean states to the ArticleBody for responsive variant properties