### PR TITLE
Uses correct svelte 5 unmount and the vars defined in the script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,25 +1,25 @@
 {
-  "name": "strib-svelte-vite-template",
-  "private": true,
-  "version": "0.2.1",
-  "type": "module",
-  "scripts": {
-    "dev": "vite --host",
-    "build": "vite build",
-    "preview": "vite preview",
-    "svelte-check": "svelte-check",
-    "deploy-staging": "./strib-deploy.sh --environment staging",
-    "deploy-production": "./strib-deploy.sh --environment production"
-  },
-  "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^5.0.1",
-    "autoprefixer": "^10.4.19",
-    "postcss": "^8.4.39",
-    "postcss-prefix-selector": "^2.1.0",
-    "svelte": "^5.2.9",
-    "svelte-check": "^4.2.2",
-    "tailwindcss": "^3.4.4",
-    "vite": "^6.0.1",
-    "vite-plugin-compression": "^0.5.1"
-  }
+    "name": "strib-svelte-vite-template",
+    "private": true,
+    "version": "0.2.2",
+    "type": "module",
+    "scripts": {
+        "dev": "vite --host",
+        "build": "vite build",
+        "preview": "vite preview",
+        "svelte-check": "svelte-check",
+        "deploy-staging": "./strib-deploy.sh --environment staging",
+        "deploy-production": "./strib-deploy.sh --environment production"
+    },
+    "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.1",
+        "autoprefixer": "^10.4.19",
+        "postcss": "^8.4.39",
+        "postcss-prefix-selector": "^2.1.0",
+        "svelte": "^5.2.9",
+        "svelte-check": "^4.2.2",
+        "tailwindcss": "^3.4.4",
+        "vite": "^6.0.1",
+        "vite-plugin-compression": "^0.5.1"
+    }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -2,27 +2,28 @@ import "./styles/tailwind/utility.css";
 import "./styles/tailwind/typography.css";
 import "./styles/tailwind/tailwind.css";
 
-import { mount } from "svelte";
+import { mount, unmount } from "svelte";
 import App from "./App.svelte";
 
 let app;
 let tgt = document.getElementById("proj-container");
 tgt.innerHTML = "";
 try {
-    mount(App, {
-        target: document.getElementById("proj-container"),
+    app = mount(App, {
+        target: tgt,
     });
 } catch {
     app = undefined;
 }
 
 setInterval(() => {
+    // Need to refind target because a rerender would break the previous link
     let tgt = document.getElementById("proj-container");
     if (tgt.innerHTML === "") {
-        if (app) app.$destroy();
+        if (app) unmount(app);
         try {
-            mount(App, {
-                target: document.getElementById("proj-container"),
+            app = mount(App, {
+                target: tgt,
             });
         } catch {
             app = undefined;


### PR DESCRIPTION
We were doing some redundant container selecting in the mounting script, and also using a deprecated function to unmount apps that was breaking in some cases. This  PR cleans up the remounting logic a bit. It appears to work fine in brief testing on stage.