### PR TITLE
Fix dropcap

### DIFF
--- a/src/components/ArticleBody/ArticleBody.svelte
+++ b/src/components/ArticleBody/ArticleBody.svelte
@@ -35,6 +35,7 @@ The following example uses a ternary to render an image edge-to-edge on mobile b
   import GridRow from "../Grid/_GridRow.svelte";
   import Subhead from "./_Subhead.svelte";
   import Paragraph from "./_Paragraph.svelte";
+  import Dropcap from "./_Dropcap.svelte";
   import Image from "../Image/Image.svelte";
   import Gallery from "../Image/Gallery.svelte";
   import ScrollySection from "../Scrolly/ScrollySection.svelte";
@@ -49,11 +50,11 @@ The following example uses a ternary to render an image edge-to-edge on mobile b
 <svelte:window bind:innerWidth />
 <Grid additionalClasses={"gap-y-5"}>
   <GridRow variant={"inline"} additionalClasses={"gap-y-5"}>
-    <Paragraph dropCap={true} dropCapLines={3}>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. <a
-        href="https://www.startribune.com/"
-        target="_blank"
-        rel="noreferrer">Debitis quas</a
+    <Paragraph>
+      <Dropcap dropCapLines={3}>L</Dropcap>orem ipsum dolor sit amet consectetur
+      adipisicing elit.
+      <a href="https://www.startribune.com/" target="_blank" rel="noreferrer"
+        >Debitis quas</a
       >, facilis itaque minus totam repudiandae magnam esse asperiores
       temporibus sed laborum nisi ut corporis ab officiis dolorum odio, porro
       eveniet. Quis quaerat tempore adipisci nostrum quia non.</Paragraph

--- a/src/components/ArticleBody/_Dropcap.svelte
+++ b/src/components/ArticleBody/_Dropcap.svelte
@@ -1,0 +1,90 @@
+<!-- 
+@component
+### Dropcap component
+Renders type in the style of a dropcap when wrapped around text.  
+
+#### Optional properties
+- dropCapLines: a number between 2 and 6 inclusive that determines how many lines of text that drop cap will span;
+- dropCapFontFamily: a string corresponding to a font's font-family attribute as defined in the this project's typography.css file. Note, this must be an actual CSS font-family string, not a Tailwind utility class name;
+
+#### Example
+```svelte
+<Paragraph><Dropcap dropCapLines={3}>H</Dropcap>ello world!</Paragraph>
+```
+-->
+
+<script>
+  /** @type {{dropCapLines?: 2|3|4|5|6; dropCapFontFamily?: String; children?: function}} */
+  let {
+    dropCapLines = 2,
+    dropCapFontFamily = "publico-headline-condensed-light",
+    children,
+  } = $props();
+</script>
+
+<span
+  class="dropcap dropcap-{dropCapLines}"
+  style:--dropcap-typeface={dropCapFontFamily}
+>
+  {@render children?.()}
+</span>
+
+<style>
+  .dropcap {
+    float: left;
+    font-family: var(--dropcap-typeface, "sans-serif");
+    line-height: 1.25;
+  }
+  /* desktop dropcap styles */
+  .dropcap-2 {
+    font-size: 50px;
+    margin-top: -8px;
+    margin-bottom: -28px;
+    padding-right: 8px;
+  }
+  .dropcap-3 {
+    font-size: 75px;
+    margin-top: -11px;
+    margin-bottom: -28px;
+    padding-right: 8px;
+  }
+  .dropcap-4 {
+    font-size: 109px;
+    margin-top: -20.3px;
+    margin-bottom: -48px;
+    padding-right: 12px;
+  }
+  .dropcap-5 {
+    font-size: 140px;
+    margin-top: -31.4px;
+    margin-bottom: -48px;
+    padding-right: 12px;
+  }
+  .dropcap-6 {
+    font-size: 200px;
+    margin-top: -43.2px;
+    margin-bottom: -48px;
+    padding-right: 12px;
+  }
+  @media screen and (max-width: 768px) {
+    .dropcap-2 {
+      margin-top: -7px;
+      margin-bottom: -20px;
+      padding-right: 6px;
+    }
+    .dropcap-3 {
+      font-size: 77px;
+      margin-top: -11px;
+      margin-bottom: -20px;
+      padding-right: 12px;
+    }
+    .dropcap-5 {
+      margin-top: -30px;
+    }
+    .dropcap-6 {
+      font-size: 168px;
+      margin-top: -36px;
+      margin-bottom: -60px;
+    }
+  }
+</style>

--- a/src/components/ArticleBody/_Paragraph.svelte
+++ b/src/components/ArticleBody/_Paragraph.svelte
@@ -4,95 +4,17 @@
 Renders a p tag in the style of the Immersive Template.  
 Wrap this component around the markup you want rendered.
 
-#### Optional properties
-- dropCap: a boolean denoting whether to make the first character of the paragraph a drop cap;
-- dropCapLines: a number between 2 and 6 inclusive that determines how many lines of text that drop cap will span;
-- dropCapFontFamily: a string corresponding to a font's font-family attribute as defined in the this project's typography.css file. Note, this must be an actual CSS font-family string, not a Tailwind utility class name;
-
 #### Example
 ```svelte
 <Paragraph>Hello world!</Paragraph>
 ```
-
-#### Dropcap example
-```svelte
-<Paragraph dropCap={true} dropCapLines={3} dropCapFontFamily={"publico-headline-black"}>Lorem ipsum</Paragraph>
-```
 -->
 
 <script>
-  /** @type {{dropCap?: Boolean; dropCapLines?: 2|3|4|5|6; dropCapFontFamily?: String; children?: function}} */
-  let {
-    dropCap = false,
-    dropCapLines = 2,
-    dropCapFontFamily = "publico-headline-condensed-light",
-    children,
-  } = $props();
+  /** @type {{children?: function}} */
+  let { children } = $props();
 </script>
 
-<p
-  class="font-editorial-body-reg-02 text-text-primary
-  {dropCap ? `dropcap dropcap-${dropCapLines}` : ''}"
-  style:--dropcap-typeface={dropCapFontFamily}
->
+<p class="font-editorial-body-reg-02 text-text-primary">
   {@render children?.()}
 </p>
-
-<style>
-  .dropcap::first-letter {
-    float: left;
-    font-family: var(--dropcap-typeface, "sans-serif");
-  }
-  /* desktop dropcap styles */
-  .dropcap-2::first-letter {
-    font-size: 50px;
-    margin-top: -8px;
-    margin-bottom: -28px;
-    padding-right: 8px;
-  }
-  .dropcap-3::first-letter {
-    font-size: 75px;
-    margin-top: -11px;
-    margin-bottom: -28px;
-    padding-right: 8px;
-  }
-  .dropcap-4::first-letter {
-    font-size: 109px;
-    margin-top: -20.3px;
-    margin-bottom: -48px;
-    padding-right: 12px;
-  }
-  .dropcap-5::first-letter {
-    font-size: 140px;
-    margin-top: -31.4px;
-    margin-bottom: -48px;
-    padding-right: 12px;
-  }
-  .dropcap-6::first-letter {
-    font-size: 200px;
-    margin-top: -43.2px;
-    margin-bottom: -48px;
-    padding-right: 12px;
-  }
-  @media screen and (max-width: 768px) {
-    .dropcap-2::first-letter {
-      margin-top: -7px;
-      margin-bottom: -20px;
-      padding-right: 6px;
-    }
-    .dropcap-3::first-letter {
-      font-size: 77px;
-      margin-top: -11px;
-      margin-bottom: -20px;
-      padding-right: 12px;
-    }
-    .dropcap-5::first-letter {
-      margin-top: -30px;
-    }
-    .dropcap-6::first-letter {
-      font-size: 168px;
-      margin-top: -36px;
-      margin-bottom: -60px;
-    }
-  }
-</style>


### PR DESCRIPTION
Previous CSS only implementation of dropcap had some rendering issues in Firefox. Refactoring to a markup/CSS hybrid fixes cross browser rendering, but necessitated that dropcap styling be handled in its own component.