### PR TITLE
Fix overflow bars on Svelte apps

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -440,6 +440,7 @@
     html {
         font-family: system-ui, sans-serif;
         scroll-behavior: smooth;
+        overflow-x: clip;
     }
 }
 


### PR DESCRIPTION
100vw measurements do not account for scrollbar width, which will introduce 15px or so of overflow for users with certain scrollbar browser settings.

This commit touches up our tailwind config to clip this x overflow.